### PR TITLE
add travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+
+go:
+  - 1.7
+  - master
+
+notifications:
+  email: false


### PR DESCRIPTION
This would run the default build for go, basically just install vendors if needed and run `go test ./...`.

You'd just have to enable travis in your project settings, it can be useful for PR reviews / merge.